### PR TITLE
Fix XML output for FINEST log level

### DIFF
--- a/stars-core/src/main/kotlin/tools/aqua/stars/core/metric/providers/Loggable.kt
+++ b/stars-core/src/main/kotlin/tools/aqua/stars/core/metric/providers/Loggable.kt
@@ -145,8 +145,8 @@ interface Loggable {
       logger.addHandler(finerFileHandler)
 
       val finestFileHandler = FileHandler("$logFolderFile/$name-${currentTimeAndDate}-finest.txt")
-      finerFileHandler.level = Level.FINEST
-      finerFileHandler.formatter = SimpleFormatter()
+      finestFileHandler.level = Level.FINEST
+      finestFileHandler.formatter = SimpleFormatter()
       logger.addHandler(finestFileHandler)
 
       logger


### PR DESCRIPTION
Correctly use the SimpleFormatter for FINEST log level.
Closes #15 