### PR TITLE
Add additional checks for the primaryEntityId getter

### DIFF
--- a/stars-data-av/src/main/kotlin/tools/aqua/stars/data/av/dataclasses/Segment.kt
+++ b/stars-data-av/src/main/kotlin/tools/aqua/stars/data/av/dataclasses/Segment.kt
@@ -42,9 +42,16 @@ data class Segment(
 
   override val primaryEntityId: Int
     get() {
-      val firstEgo = tickData.first().egoVehicle
+      val firstTick = tickData.first()
+      check(firstTick.entities.filterIsInstance<Vehicle>().any { it.egoVehicle }) {
+        "There is no primary entity for tick $firstTick"
+      }
+      val firstEgo = firstTick.egoVehicle
+      check(tickData.any { it.entities.filterIsInstance<Vehicle>().count { it.egoVehicle } == 1 }) {
+        "There is at least one tick with multiple primary entities in segment ${this.toString(firstEgo.id)}"
+      }
       if (tickData.any { it.egoVehicle.id != firstEgo.id })
-          error("inconsistent ego ids in segment $this")
+          error("The ego id changes in Segment ${this.toString(firstEgo.id)}")
       return firstEgo.id
     }
 
@@ -81,9 +88,11 @@ data class Segment(
       return pedestrianIdsCache
     }
 
-  override fun toString(): String =
+  override fun toString(): String = toString(this.primaryEntityId)
+
+  fun toString(egoId: Int): String =
       "Segment[(${tickData.first().currentTick}..${tickData.last().currentTick})] from $simulationRunId " +
-          "with ego ${this.primaryEntityId}"
+          "with ego $egoId"
 
   override fun equals(other: Any?): Boolean {
     if (other is Segment) {

--- a/stars-data-av/src/main/kotlin/tools/aqua/stars/data/av/dataclasses/Segment.kt
+++ b/stars-data-av/src/main/kotlin/tools/aqua/stars/data/av/dataclasses/Segment.kt
@@ -88,11 +88,16 @@ data class Segment(
       return pedestrianIdsCache
     }
 
-  override fun toString(): String = toString(this.primaryEntityId)
-
+  /**
+   * Converts segment to String representation including [tickData] range and given [egoId].
+   *
+   * @param egoId Identifier of the ego vehicle to be included.
+   */
   fun toString(egoId: Int): String =
       "Segment[(${tickData.first().currentTick}..${tickData.last().currentTick})] from $simulationRunId " +
           "with ego $egoId"
+
+  override fun toString(): String = toString(this.primaryEntityId)
 
   override fun equals(other: Any?): Boolean {
     if (other is Segment) {

--- a/stars-data-av/src/test/kotlin/tools/aqua/stars/data/av/dataclasses/SegmentPrimaryEntityTest.kt
+++ b/stars-data-av/src/test/kotlin/tools/aqua/stars/data/av/dataclasses/SegmentPrimaryEntityTest.kt
@@ -23,7 +23,12 @@ import kotlin.test.assertFailsWith
 import tools.aqua.stars.data.av.emptyTickData
 import tools.aqua.stars.data.av.emptyVehicle
 
-class SegmentToStringTest {
+/**
+ * This class tests the correctness of the [Segment.primaryEntityId] for [Segment]s. The primary
+ * entity has constraints, such as 'in each tick there should be exactly one primary entity' and
+ * 'the primary entity should be consistent in the whole segment'.
+ */
+class SegmentPrimaryEntityTest {
   /**
    * This test checks that an exception is thrown, when there is no primary entity in a [Segment].
    */

--- a/stars-data-av/src/test/kotlin/tools/aqua/stars/data/av/dataclasses/SegmentToStringTest.kt
+++ b/stars-data-av/src/test/kotlin/tools/aqua/stars/data/av/dataclasses/SegmentToStringTest.kt
@@ -71,13 +71,14 @@ class SegmentToStringTest {
    */
   @Test
   fun testChangingEgoVehicles() {
-    val vehicle1_1 = emptyVehicle(id = 0, egoVehicle = true)
-    val vehicle2_1 = emptyVehicle(id = 1, egoVehicle = false)
-    val tickData = emptyTickData(actors = listOf(vehicle1_1, vehicle2_1))
+    val vehicle1 = emptyVehicle(id = 0, egoVehicle = true)
+    val vehicle2 = emptyVehicle(id = 1, egoVehicle = false)
+    val tickData = emptyTickData(actors = listOf(vehicle1, vehicle2))
+
     // Change egoVehicle flag
-    val vehicle1_2 = emptyVehicle(id = 0, egoVehicle = false)
-    val vehicle2_2 = emptyVehicle(id = 1, egoVehicle = true)
-    val tickData2 = emptyTickData(actors = listOf(vehicle1_2, vehicle2_2))
+    val changedVehicle1 = emptyVehicle(id = 0, egoVehicle = false)
+    val changedVehicle2 = emptyVehicle(id = 1, egoVehicle = true)
+    val tickData2 = emptyTickData(actors = listOf(changedVehicle1, changedVehicle2))
 
     val segment =
         Segment(

--- a/stars-data-av/src/test/kotlin/tools/aqua/stars/data/av/dataclasses/SegmentToStringTest.kt
+++ b/stars-data-av/src/test/kotlin/tools/aqua/stars/data/av/dataclasses/SegmentToStringTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 The STARS Project Authors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tools.aqua.stars.data.av.dataclasses
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import tools.aqua.stars.data.av.emptyTickData
+import tools.aqua.stars.data.av.emptyVehicle
+
+class SegmentToStringTest {
+  /**
+   * This test checks that an exception is thrown, when there is no primary entity in a [Segment].
+   */
+  @Test
+  fun testNoEgoVehicle() {
+    val vehicle1 = emptyVehicle(id = 0, egoVehicle = false)
+    val vehicle2 = emptyVehicle(id = 1, egoVehicle = false)
+    val tickData = emptyTickData(actors = listOf(vehicle1, vehicle2))
+    val segment =
+        Segment(segmentSource = "", mainInitList = listOf(tickData), simulationRunId = "1")
+    assertFailsWith<IllegalStateException> { segment.primaryEntityId }
+  }
+
+  /**
+   * This test checks that there is no exception when exactly one primary entity is present in a
+   * [Segment].
+   */
+  @Test
+  fun testHasEgoVehicle() {
+    val vehicle1 = emptyVehicle(id = 0, egoVehicle = true)
+    val vehicle2 = emptyVehicle(id = 1, egoVehicle = false)
+    val tickData = emptyTickData(actors = listOf(vehicle1, vehicle2))
+    val segment =
+        Segment(segmentSource = "", mainInitList = listOf(tickData), simulationRunId = "1")
+    assertEquals(segment.primaryEntityId, vehicle1.id)
+  }
+
+  /**
+   * This test checks that an exception is thrown when there are multiple primary entities in a
+   * [Segment].
+   */
+  @Test
+  fun testHasMultipleEgoVehicles() {
+    val vehicle1 = emptyVehicle(id = 0, egoVehicle = true)
+    val vehicle2 = emptyVehicle(id = 1, egoVehicle = true)
+    val tickData = emptyTickData(actors = listOf(vehicle1, vehicle2))
+    val segment =
+        Segment(segmentSource = "", mainInitList = listOf(tickData), simulationRunId = "1")
+    assertFailsWith<IllegalStateException> { segment.primaryEntityId }
+  }
+
+  /**
+   * This test checks that an exception is thrown when the primary entity changed during a [Segment]
+   * .
+   */
+  @Test
+  fun testChangingEgoVehicles() {
+    val vehicle1_1 = emptyVehicle(id = 0, egoVehicle = true)
+    val vehicle2_1 = emptyVehicle(id = 1, egoVehicle = false)
+    val tickData = emptyTickData(actors = listOf(vehicle1_1, vehicle2_1))
+    // Change egoVehicle flag
+    val vehicle1_2 = emptyVehicle(id = 0, egoVehicle = false)
+    val vehicle2_2 = emptyVehicle(id = 1, egoVehicle = true)
+    val tickData2 = emptyTickData(actors = listOf(vehicle1_2, vehicle2_2))
+
+    val segment =
+        Segment(
+            segmentSource = "", mainInitList = listOf(tickData, tickData2), simulationRunId = "1")
+
+    assertFailsWith<IllegalStateException> { segment.primaryEntityId }
+  }
+}


### PR DESCRIPTION
Also fixes StackOverflow exception in rare cases in toString() function of Segment.

fixes #29 